### PR TITLE
Drop (inert) pypy listing in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, quality, py37, py38 pypy, docs
+envlist = py36, quality, py37, py38, docs
 skipsdist = true
 
 [testenv:docs]


### PR DESCRIPTION
This hasn't been tested to my knowledge.