### PR TITLE
Add /dist/ back to .gitignore

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -52,6 +52,7 @@ __pycache__/
 /eggs/
 /.eggs/
 /parts/
+/dist/
 /sdist/
 /wheels/
 *.egg-info/


### PR DESCRIPTION
(it's used for generated files during the PyPI publish process)