### PR TITLE
Clean up test_cli_help()

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -5,6 +5,7 @@
 # from {{ cookiecutter.project_slug }} import {{ cookiecutter.project_slug }}
 {%- if cookiecutter.command_line_interface|lower == 'argparse' %}
 import argparse
+import os
 import subprocess
 from unittest.mock import call, patch
 {%- endif %}
@@ -52,6 +53,10 @@ def test_parse_argv_run_simple():
 
 
 def test_cli_help():
+    request_long_lines = {'COLUMNS': '999', 'LINES': '25'}
+    env = {}
+    env.update(os.environ)
+    env.update(request_long_lines)
     expected_help = """usage: {{ cookiecutter.project_slug }} [-h] {op1} ...
 
 positional arguments:
@@ -62,10 +67,7 @@ optional arguments:
   -h, --help  show this help message and exit
 """
     # older python versions show arguments like this:
-    alt_expected_help = expected_help.replace('[_ ...]', '[_ [_ ...]]')
-    actual_help = subprocess.check_output(['{{ cookiecutter.project_slug }}', '--help']).decode('utf-8')
-    try:
-        assert actual_help == expected_help
-    except AssertionError:
-        assert actual_help == alt_expected_help
+    actual_help = subprocess.check_output(['{{ cookiecutter.project_slug }}', '--help'],
+                                          env=env).decode('utf-8')
+    assert actual_help == expected_help
 {%- endif %}


### PR DESCRIPTION
* Ensure tests are run in long-lines mode for consistency in debugging
* Drop workaround for legacy issue