### PR TITLE
Python 3.10 fixes, inc. add libxml and libxslt for lxml package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
             equal: [<< pipeline.git.branch >>, "main"]
           steps:
             - tox:
-                tox_arguments: '-e py39'
+                tox_arguments: '-e py310'
       - when:
           condition:
             equal: [<< pipeline.git.branch >>, "main"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ cookiecutter>=1.4.0
 flake8==3.8.4
 flake8-import-order==0.18.1
 pip==21.0.1
-pytest-cookies==0.5.1
+pytest-cookies==0.6.1
 pytest==6.2.4
 tox==3.14.1
 watchdog==0.9.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ flake8==3.8.4
 flake8-import-order==0.18.1
 pip==21.0.1
 pytest-cookies==0.5.1
-pytest==5.3.1
+pytest==6.2.4
 tox==3.14.1
 watchdog==0.9.0
 yamllint==1.26.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, docs
+envlist = py36, py37, py38, py39, py310, docs
 skipsdist = true
 
 [testenv:docs]

--- a/{{cookiecutter.project_slug}}/fix.sh
+++ b/{{cookiecutter.project_slug}}/fix.sh
@@ -283,7 +283,20 @@ ensure_pip() {
   fi
 }
 
+ensure_python_requirements_build_requirements() {
+  # During the Python 3.10 beta period, the lxml package didn't have a
+  # prebuilt binary for at least Linux on CircleCI:
+  #
+  # https://app.circleci.com/pipelines/github/apiology/docker-circleci/124/workflows/91397303-085c-46fe-bf2b-93c3e0e0f615/jobs/236
+  #
+  # While this can probably be removed, maybe it'll be required again
+  # for the next beta period?
+  ensure_dev_library xslt.h libxslt libxslt-dev
+  ensure_dev_library libxml/xmlschemas.h libxml2 libxml2-dev
+}
+
 ensure_python_requirements() {
+  ensure_python_requirements_build_requirements
   make pip_install
 }
 

--- a/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.project_slug}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -73,7 +73,7 @@ Do some kind of operation
 positional arguments:
   arg1        arg1 help
 
-optional arguments:
+options:
   -h, --help  show this help message and exit
 """
     # older python versions show arguments like this:
@@ -110,7 +110,7 @@ positional arguments:
   {op1}
     op1       Do some kind of operation
 
-optional arguments:
+options:
   -h, --help  show this help message and exit
 """
     # older python versions show arguments like this:

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 [testenv]
 setenv =


### PR DESCRIPTION
During the Python 3.10 beta period, the lxml package didn't have a
prebuilt binary for at least Linux on CircleCI:

https://app.circleci.com/pipelines/github/apiology/docker-circleci/124/workflows/91397303-085c-46fe-bf2b-93c3e0e0f615/jobs/236

While this can probably be removed, maybe it'll be required again...