### PR TITLE
Use circleci-python image in build phase in CircleCI as well

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
   build:
     working_directory: ~/{{cookiecutter.project_slug}}
     docker:
-      - image: apiology/circleci:latest
+      - image: apiology/circleci-python:latest
     steps:
       - set_up_environment
       - unless:


### PR DESCRIPTION
Otherwise it will spend forever installing other Python versions...